### PR TITLE
New termination criteria for SWR

### DIFF
--- a/AOSCMcoupling/convergence_checker.py
+++ b/AOSCMcoupling/convergence_checker.py
@@ -6,57 +6,83 @@ import xarray as xr
 from AOSCMcoupling.files import OASISPreprocessor
 
 
+def vector_norm(x, dim, ord=None):
+    return xr.apply_ufunc(
+        np.linalg.norm,
+        x,
+        input_core_dims=[[dim]],
+        kwargs={"ord": ord, "axis": -1},
+        dask="allowed",
+    )
+
+
 class ConvergenceChecker:
     """Wrapper to compute termination criteria for Schwarz iterations."""
 
     def __init__(self, tolerance: float = 1e-3):
         self.preprocessor = OASISPreprocessor()
         self.coupling_vars = [
-            "O_OTaux1",
-            "O_OTauy1",
-            "O_QsrMix",
-            "O_QnsMix",
-            "OTotEvap",
-            "OTotRain",
-            "OTotSnow",
-            "A_SST",
-            "A_Ice_temp",
-            "A_Ice_albedo",
-            "A_Ice_frac",
-            "A_Ice_thickness",
-            "A_Snow_thickness",
+            "A_TauX_oce",
+            "A_TauY_oce",
+            "A_TauX_ice",
+            "A_TauY_ice",
+            "A_Qs_mix",
+            "A_Qns_mix",
+            "A_Qs_ice",
+            "A_Qns_ice",
+            "A_Precip_liquid",
+            "A_Precip_solid",
+            "A_Evap_total",
+            "A_Evap_ice",
+            "A_dQns_dT",
+            "O_SSTSST",
+            "O_TepIce",
+            "O_AlbIce",
+            "OIceFrc",
+            "OIceTck",
+            "OSnwTck",
         ]
         self.tolerance = tolerance
+        self.reference = None
+        self.current_iterate = None
+        self.previous_iterate = None
 
-    def check_convergence(self, iterate_output: Path, reference_output: Path):
+    def load_reference_data(self, reference_rundir: Path):
         coupling_files_reference = [
-            next(reference_output.glob(f"{coupling_var}.nc"))
-            for coupling_var in self.coupling_vars
-        ]
-        coupling_files_iterate = [
-            next(iterate_output.glob(f"{coupling_var}.nc"))
+            next(reference_rundir.glob(f"{coupling_var}_*.nc"))
             for coupling_var in self.coupling_vars
         ]
         self.reference = xr.open_mfdataset(
             coupling_files_reference, preprocess=self.preprocessor.preprocess
         )
-        self.iterate = xr.open_mfdataset(
-            coupling_files_iterate, preprocess=self.preprocessor.preprocess
+
+    def check_convergence(self, current_iterate: Path, previous_iterate: Path):
+        if self.reference is None:
+            raise ValueError("Reference data needs to be loaded to check convergence!")
+
+        current_coupling_files = [
+            next(current_iterate.glob(f"{coupling_var}_*.nc"))
+            for coupling_var in self.coupling_vars
+        ]
+        self.current_iterate = xr.open_mfdataset(
+            current_coupling_files, preprocess=self.preprocessor.preprocess
         )
-        local_convergence = self._check_local_convergence()
-        amplitude_convergence = self._check_amplitude_convergence()
-        return local_convergence, amplitude_convergence
+        previous_coupling_files = [
+            next(previous_iterate.glob(f"{coupling_var}_*.nc"))
+            for coupling_var in self.coupling_vars
+        ]
+        self.previous_iterate = xr.open_mfdataset(
+            previous_coupling_files, preprocess=self.preprocessor.preprocess
+        )
+        conv_2_norm = self._check_convergence(ord=2)
+        conv_inf_norm = self._check_convergence(ord=np.inf)
+        return conv_2_norm, conv_inf_norm
 
-    def _check_local_convergence(self) -> bool:
-        converged_wrt_data_value = (
-            np.abs(self.reference - self.iterate) <= 1e-3 * np.abs(self.reference)
-        ).all()
+    def _check_convergence(self, ord=np.inf) -> bool:
+        normed_delta = vector_norm(
+            self.current_iterate - self.previous_iterate, "time", ord=ord
+        )
+        normed_reference = vector_norm(self.reference, "time", ord=ord)
+        converged_wrt_data_value = normed_delta <= self.tolerance * normed_reference
         converged_successful = converged_wrt_data_value.to_numpy().all()
-        return bool(converged_successful)
-
-    def _check_amplitude_convergence(self) -> bool:
-        amplitudes = np.max(self.reference) - np.min(self.reference)
-        max_abs_diff = np.max(np.abs(self.reference - self.iterate))
-        converged_wrt_amplitude = max_abs_diff <= 1e-3 * amplitudes
-        converged_successful = converged_wrt_amplitude.to_numpy().all()
         return bool(converged_successful)

--- a/AOSCMcoupling/convergence_checker.py
+++ b/AOSCMcoupling/convergence_checker.py
@@ -44,7 +44,7 @@ def relative_criterion(
     rel_tol: float,
     ord=np.inf,
 ) -> bool:
-    """Determines whether ||iterate_1 - iterate_2||_ord < rel_tol * ||reference||_ord.
+    """Determines whether ||iterate_1 - iterate_2||_ord <= rel_tol * ||reference||_ord.
 
     :param iterate_1: Dataset with 'time' coordinate.
     :type iterate_1: xr.Dataset
@@ -61,7 +61,7 @@ def relative_criterion(
     """
     normed_delta = vector_norm(iterate_1 - iterate_2, "time", ord=ord)
     normed_reference = vector_norm(reference, "time", ord=ord)
-    converged_wrt_data_value = normed_delta < rel_tol * normed_reference
+    converged_wrt_data_value = normed_delta <= rel_tol * normed_reference
     converged = converged_wrt_data_value.to_numpy().all()
     return bool(converged)
 

--- a/AOSCMcoupling/convergence_checker.py
+++ b/AOSCMcoupling/convergence_checker.py
@@ -16,10 +16,60 @@ def vector_norm(x, dim, ord=None):
     )
 
 
+def relative_error(
+    iterate_1: xr.Dataset, iterate_2: xr.Dataset, reference: xr.Dataset, ord=np.inf
+) -> xr.Dataset:
+    """Compute e_rel = ||iterate_1 - iterate_2||_ord / ||reference||_ord.
+
+    :param iterate_1: Dataset with 'time' coordinate.
+    :type iterate_1: xr.Dataset
+    :param iterate_2: Dataset with 'time' coordinate.
+    :type iterate_2: xr.Dataset
+    :param reference: Dataset with 'time' coordinate.
+    :type reference: xr.Dataset
+    :param ord: Order of the norm, defaults to np.inf
+    :type ord: {non-zero int, inf, -inf, 'fro', 'nuc'}, optional
+    :return: e_rel, preserving variables from the input datasets.
+    :rtype: xr.Dataset
+    """
+    normed_delta = vector_norm(iterate_1 - iterate_2, "time", ord=ord)
+    normed_reference = vector_norm(reference, "time", ord=ord)
+    return normed_delta / normed_reference
+
+
+def relative_criterion(
+    iterate_1: xr.Dataset,
+    iterate_2: xr.Dataset,
+    reference: xr.Dataset,
+    rel_tol: float,
+    ord=np.inf,
+) -> bool:
+    """Determines whether ||iterate_1 - iterate_2||_ord < rel_tol * ||reference||_ord.
+
+    :param iterate_1: Dataset with 'time' coordinate.
+    :type iterate_1: xr.Dataset
+    :param iterate_2: Dataset with 'time' coordinate.
+    :type iterate_2: xr.Dataset
+    :param reference: Dataset with 'time' coordinate.
+    :type reference: xr.Dataset
+    :param rel_tol: Tolerance
+    :type rel_tol: float
+    :param ord: Order of the norm, defaults to np.inf
+    :type ord: {non-zero int, inf, -inf, 'fro', 'nuc'}, optional
+    :return: Whether the above criterion is satisfied.
+    :rtype: bool
+    """
+    normed_delta = vector_norm(iterate_1 - iterate_2, "time", ord=ord)
+    normed_reference = vector_norm(reference, "time", ord=ord)
+    converged_wrt_data_value = normed_delta < rel_tol * normed_reference
+    converged = converged_wrt_data_value.to_numpy().all()
+    return bool(converged)
+
+
 class ConvergenceChecker:
     """Wrapper to compute termination criteria for Schwarz iterations."""
 
-    def __init__(self, tolerance: float = 1e-3):
+    def __init__(self):
         self.preprocessor = OASISPreprocessor()
         self.coupling_vars = [
             "A_TauX_oce",
@@ -42,12 +92,11 @@ class ConvergenceChecker:
             "OIceTck",
             "OSnwTck",
         ]
-        self.tolerance = tolerance
         self.reference = None
-        self.current_iterate = None
-        self.previous_iterate = None
+        self.iterate_1 = None
+        self.iterate_2 = None
 
-    def load_reference_data(self, reference_rundir: Path):
+    def _load_reference_data(self, reference_rundir: Path):
         coupling_files_reference = [
             next(reference_rundir.glob(f"{coupling_var}_*.nc"))
             for coupling_var in self.coupling_vars
@@ -56,33 +105,42 @@ class ConvergenceChecker:
             coupling_files_reference, preprocess=self.preprocessor.preprocess
         )
 
-    def check_convergence(self, current_iterate: Path, previous_iterate: Path):
+    def check_convergence(
+        self,
+        iterate_1_dir: Path,
+        iterate_2_dir: Path,
+        reference_dir: Path,
+        tolerance: float,
+    ):
         if self.reference is None:
-            raise ValueError("Reference data needs to be loaded to check convergence!")
+            self._load_reference_data(reference_dir)
 
-        current_coupling_files = [
-            next(current_iterate.glob(f"{coupling_var}_*.nc"))
+        coupling_files_1 = [
+            next(iterate_1_dir.glob(f"{coupling_var}_*.nc"))
             for coupling_var in self.coupling_vars
         ]
-        self.current_iterate = xr.open_mfdataset(
-            current_coupling_files, preprocess=self.preprocessor.preprocess
+        self.iterate_1 = xr.open_mfdataset(
+            coupling_files_1, preprocess=self.preprocessor.preprocess
         )
-        previous_coupling_files = [
-            next(previous_iterate.glob(f"{coupling_var}_*.nc"))
+        coupling_files_2 = [
+            next(iterate_2_dir.glob(f"{coupling_var}_*.nc"))
             for coupling_var in self.coupling_vars
         ]
-        self.previous_iterate = xr.open_mfdataset(
-            previous_coupling_files, preprocess=self.preprocessor.preprocess
+        self.iterate_2 = xr.open_mfdataset(
+            coupling_files_2, preprocess=self.preprocessor.preprocess
         )
-        conv_2_norm = self._check_convergence(ord=2)
-        conv_inf_norm = self._check_convergence(ord=np.inf)
+        conv_2_norm = relative_criterion(
+            self.iterate_1,
+            self.iterate_2,
+            self.reference,
+            tolerance,
+            2,
+        )
+        conv_inf_norm = relative_criterion(
+            self.iterate_1,
+            self.iterate_2,
+            self.reference,
+            tolerance,
+            np.inf,
+        )
         return conv_2_norm, conv_inf_norm
-
-    def _check_convergence(self, ord=np.inf) -> bool:
-        normed_delta = vector_norm(
-            self.current_iterate - self.previous_iterate, "time", ord=ord
-        )
-        normed_reference = vector_norm(self.reference, "time", ord=ord)
-        converged_wrt_data_value = normed_delta <= self.tolerance * normed_reference
-        converged_successful = converged_wrt_data_value.to_numpy().all()
-        return bool(converged_successful)

--- a/AOSCMcoupling/experiment.py
+++ b/AOSCMcoupling/experiment.py
@@ -41,7 +41,7 @@ class Experiment:
     ice_nlay_i: int = 2
     ice_jpl: int = 5
     iteration: int = None
-    previous_iter_converged: dict[str, bool] = None
+    iterate_converged: dict[str, bool] = None
 
     def __post_init__(self):
         self.nem_input_file = Path(self.nem_input_file)

--- a/AOSCMcoupling/helpers.py
+++ b/AOSCMcoupling/helpers.py
@@ -93,19 +93,19 @@ def reduce_output(run_directory: Path, keep_debug_output: bool = True) -> None:
     output_files = list(run_directory.glob("*"))
     output_files_to_remove = []
     for output_file in output_files:
-        if "diagvar" in output_file.name:
-            continue
-        if "progvar" in output_file.name:
-            continue
-        if "_grid_" in output_file.name:
-            continue
-        if "_icemod" in output_file.name:
-            continue
-        if "namelist_" in output_file.name:
-            continue
-        if output_file.name == "namcouple":
-            continue
-        if output_file.name == "fort.4":
+        whitelisted = [
+            "diagvar",
+            "progvar",
+            "_grid_",
+            "_icemod",
+            "_OpenIFS_",
+            "_ATMIFS_",
+            "_oceanx_",
+            "namelist_",
+            "namcouple",
+            "fort.4",
+        ]
+        if any(wl in output_file.name for wl in whitelisted):
             continue
         if keep_debug_output:
             if "debug" in output_file.name:

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -1,0 +1,19 @@
+import numpy as np
+import xarray as xr
+from AOSCMcoupling.convergence_checker import vector_norm, relative_criterion
+
+
+def test_vector_norm():
+    arr = np.random.rand(5)
+    da = xr.DataArray(arr)
+    assert np.isclose(np.linalg.norm(arr), vector_norm(da, "dim_0"))
+    assert np.isclose(np.linalg.norm(arr, np.inf), vector_norm(da, "dim_0", np.inf))
+
+
+def test_relative_criterion():
+    arr_1 = np.random.rand(5)
+    arr_2 = arr_1 * (1 + 1e-4)
+    da_1 = xr.DataArray(arr_1, dims="time")
+    da_2 = xr.DataArray(arr_2, dims="time")
+    assert relative_criterion(da_1, da_2, da_1, 1e-3)
+    assert not relative_criterion(da_1, da_2, da_1, 1e-5)


### PR DESCRIPTION
- check for current, not previous iterate
- replace "local" and "amplitude" with a 2-norm and inf-norm based criterion, use iteration 1 as reference iterate during runs: ||c^k - c^k-1|| < TOL * ||c^1||
- adjust reduce_output to keep OASIS files for this purpose (this sadly means that more files will be kept)
- refactor reduce_output using any() for string checks